### PR TITLE
fix(doc): fix README.md alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ For simplicity, only installation method for now is `cargo install`.
 
 **this readme will be extended again, pending some rewrites / updates.** 
 
+</div>
+
 ![Screenshots of zetta](screenshots.png)
 
 ---


### PR DESCRIPTION
Fixes alignment issue of options due to a missing closing div tag.

This should be a trivial change.

(the change can be preview at https://github.com/cafkafk/zetta/tree/patch-1)